### PR TITLE
Transparent search bar

### DIFF
--- a/app/assets/stylesheets/components/_search_bar.scss
+++ b/app/assets/stylesheets/components/_search_bar.scss
@@ -18,6 +18,7 @@
   .fas.fa-search {
     align-items: center;
     background: $white;
+    background-color: $light-80;
     color: $my-green;
     display: flex;
     flex-direction: column;
@@ -30,6 +31,7 @@
 }
 
 .search-bar-input {
+  background-color: $light-80;
   border: 0;
   color: $gray;
   height: 100%;

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -16,18 +16,19 @@ $my-green: #49af91;
 $my-pink: #ef798a;
 $my-sand: #dbcaa2;
 
-$rock: #B12D24;
-$electro: #97EBDC;
+$rock: #b12d24;
+$electro: #97ebdc;
 $pop: #1d96a3;
 $rap: #dbcaa2;
 $jazz: #a85e32;
-$country: #CDA552;
+$country: #cda552;
 $soul: #4432a8;
-$hip-hop: #E25D31;
-$rnb: #C9418E;
-$techno: #4D96EF;
+$hip-hop: #e25d31;
+$rnb: #c9418e;
+$techno: #4d96ef;
 $italo-disco: #a31d38;
 $hard-rock: #dbcaa2;
 $metal: #464646;
 
 $shadow-20: rgba(0, 0, 0, 0.2);
+$light-80: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
<img width="420" alt="Capture d’écran 2020-02-26 à 00 22 46" src="https://user-images.githubusercontent.com/1598346/75296675-2292b000-582e-11ea-9220-d856d077674e.png">
