### PR TITLE
Tastes Page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,10 @@ body {
   font-family: "Hind";
 }
 
+h3 {
+  font-size: 36px;
+}
+
 .grid-content {
   display: grid;
   grid-template-areas:
@@ -42,8 +46,8 @@ body {
   overflow-y: scroll;
 }
 
-#sessions-new {
-  .grid-content .app-navbar .bottom-navbar {
-    visibility: hidden;
+#sessions-new, #pages-tastes {
+  .grid-content .app-navbar {
+    display: none;
   }
 }

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -1,13 +1,13 @@
 .btn {
   line-height: 31px;
-  padding: 5px 22px;
+  padding: 5px 32px;
   border: 0;
   margin: 10px;
   cursor: pointer;
   border-radius: 100px;
   text-decoration: none;
   font-weight: 600;
-  font-size: 24px;
+  font-size: 20px;
   outline: none !important;
   transition: 0.2s ease-out;
   vertical-align: middle;
@@ -16,8 +16,11 @@
 .btn-default {
   color: $my-white;
   background-color: $my-pink;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   min-width: 160px;
-  min-height: 64px;
 }
 
 .btn-signin {

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -2,3 +2,4 @@
 @import "sessions_new";
 @import "places_index";
 @import "show";
+@import "tastes";

--- a/app/assets/stylesheets/pages/_tastes.scss
+++ b/app/assets/stylesheets/pages/_tastes.scss
@@ -45,6 +45,7 @@
         display: flex;
         flex-wrap: wrap;
         margin: 0 16px;
+        justify-content: center;
 
         .tag {
           padding: 4px 12px;

--- a/app/assets/stylesheets/pages/_tastes.scss
+++ b/app/assets/stylesheets/pages/_tastes.scss
@@ -1,0 +1,79 @@
+.tastes {
+  .tastes-content {
+    display: grid;
+    grid-template-areas:
+      "scrollable"
+      "sticky-button";
+
+    grid-template-rows: 1fr auto;
+    height: 100vh;
+
+    .scrollable {
+
+      overflow-y: scroll;
+      overflow-x: hidden;
+
+      .logo {
+        width: 100%;
+        height: 190px;
+        display: flex;
+        justify-content: center;
+      }
+
+      h3 {
+        color: $my-white;
+        font-weight: 600;
+      }
+
+      .headers {
+        display: flex;
+
+        .headers-content {
+          margin-left: 7vw;
+
+          #tastes-header-2 {
+            margin-left: 45vw;
+          }
+        }
+
+        .question-mark h3 {
+          font-size: 96px;
+        }
+      }
+
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        margin: 0 16px;
+
+        .tag {
+          padding: 4px 12px;
+          margin: 8px 4px;
+          border-radius: 100px;
+        }
+      }
+    }
+
+    .sticky-button {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin: 24px 0;
+      position: relative;
+
+      .skip-link {
+        position: absolute;
+        right: 32px;
+        bottom: 16px;
+        a {
+          color: $my-pink;
+          text-decoration: none;
+
+          &:hover {
+            text-decoration: none;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,4 +19,7 @@ class ApplicationController < ActionController::Base
     devise_controller? || params[:controller] =~ /(^(rails_)?admin)|(^pages$)/
   end
 
+  def after_sign_in_path_for(resource)
+    resource.viewed_tag_screen ? super : tastes_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,6 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    resource.viewed_tag_screen ? super : tastes_path
+    resource.viewed_tastes_screen ? super : tastes_path
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,10 @@
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: [:home]
-  def home
+
+  def home; end
+
+  def tastes
+    current_user.viewed_tastes_screen = true
+    @color = 'ef798a'
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,6 +5,11 @@ class PagesController < ApplicationController
 
   def tastes
     current_user.viewed_tastes_screen = true
-    @color = 'ef798a'
+    current_user.save
+    @genres = Genre
+              .all
+              .select("genres.*, user_genres.user_id")
+              .joins("left join user_genres on user_genres.genre_id = genres.id and user_genres.user_id = #{current_user.id}")
+              .order('user_genres.user_id, genres.name ASC')
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,3 +22,6 @@ require("channels")
 // WRITE YOUR OWN JS STARTING FROM HERE 👇
 // ----------------------------------------------------
 import "bootstrap";
+import {initFillTag} from "../plugins/tastes.js";
+
+initFillTag();

--- a/app/javascript/plugins/tastes.js
+++ b/app/javascript/plugins/tastes.js
@@ -3,15 +3,21 @@ const initFillTag = () => {
 
     const tags = document.querySelectorAll(".tag");
 
+    const toggleTagStyle = (tag, setup) => {
+      console.log(tag.dataset.chosen === setup)
+      if (tag.dataset.chosen === "true") {
+        tag.setAttribute("style", `border: 1px solid ${tag.dataset.color}; color: #fffdf7; box-shadow: 0 0px 4px 0px ${tag.dataset.color}; background: ${tag.dataset.color}`);
+        tag.dataset.chosen = "false"
+      } else {
+        tag.setAttribute("style", `border: 1px solid #ef798a; color: #ef798a; box-shadow: 0 0px 4px 0px #ef798a;`);
+        tag.dataset.chosen = "true"
+      }
+    }
+
     tags.forEach((tag) => {
+      toggleTagStyle(tag, "true");
       tag.addEventListener('click', (event) => {
-        if (tag.dataset.chosen === "true") {
-          event.currentTarget.setAttribute("style", "border: 1px solid #ef798a; color: #ef798a; box-shadow: 0 0px 4px 0px #ef798a;");
-          tag.dataset.chosen = false
-        } else {
-          event.currentTarget.setAttribute("style", "border: 1px solid #251351; color: #fffdf7; box-shadow: 0 0px 4px 0px #251351; background: #251351");
-          tag.dataset.chosen = true
-        }
+        toggleTagStyle(event.currentTarget, "false");
       });
     });
   };

--- a/app/javascript/plugins/tastes.js
+++ b/app/javascript/plugins/tastes.js
@@ -1,0 +1,20 @@
+const initFillTag = () => {
+  if (document.querySelector(".tastes")) {
+
+    const tags = document.querySelectorAll(".tag");
+
+    tags.forEach((tag) => {
+      tag.addEventListener('click', (event) => {
+        if (tag.dataset.chosen === "true") {
+          event.currentTarget.setAttribute("style", "border: 1px solid #ef798a; color: #ef798a; box-shadow: 0 0px 4px 0px #ef798a;");
+          tag.dataset.chosen = false
+        } else {
+          event.currentTarget.setAttribute("style", "border: 1px solid #251351; color: #fffdf7; box-shadow: 0 0px 4px 0px #251351; background: #251351");
+          tag.dataset.chosen = true
+        }
+      });
+    });
+  };
+};
+
+export {initFillTag};

--- a/app/views/pages/tastes.html.erb
+++ b/app/views/pages/tastes.html.erb
@@ -14,66 +14,9 @@
         </div>
       </div>
       <div class="tags">
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
-        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
+        <% @genres.each do |genre| %>
+          <div class="tag" data-chosen= "<%= genre.user_id.present? %>" data-color="<%= genre.color_hex %>" style="border: 1px solid #ef798a; color: #ef798a; box-shadow: 0 0px 4px 0px #ef798a;"><%= genre.name.capitalize %></div>
+        <% end %>
       </div>
     </div>
     <div class="sticky-button">

--- a/app/views/pages/tastes.html.erb
+++ b/app/views/pages/tastes.html.erb
@@ -1,0 +1,86 @@
+<div class="tastes">
+  <div class="tastes-content">
+    <div class="scrollable">
+      <div class="logo">
+        <%= image_tag "logo_with_arrow" %>
+      </div>
+      <div class="headers">
+        <div class="headers-content">
+          <h3 id="tastes-header-1">What do you</h3>
+          <h3 id="tastes-header-2">listen to</h3>
+        </div>
+        <div class="question-mark">
+          <h3>?</h3>
+        </div>
+      </div>
+      <div class="tags">
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Techno</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Jazz</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Classical</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">R&B</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Afro</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Latin</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">House</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Hip-Hop</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Soul</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">He</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Blues</div>
+        <div class="tag" data-chosen= "false" style="border: 1px solid #<%= @color %>; color: #<%= @color %>; box-shadow: 0 0px 4px 0px #<%= @color %>;">Electronica</div>
+      </div>
+    </div>
+    <div class="sticky-button">
+      <%= render 'components/button_link', text: "Next" %>
+      <div class="skip-link">
+        <%= link_to "Skip", root_path %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root to: 'pages#home'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
-
   resources :places, only: %i[index show]
+  get '/tastes', to: 'pages#tastes', as: 'tastes'
 end

--- a/db/migrate/20200226165857_add_last_spotify_signin_to_users.rb
+++ b/db/migrate/20200226165857_add_last_spotify_signin_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastSpotifySigninToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :last_spotify_signin, :timestamp
+  end
+end

--- a/db/migrate/20200226171803_remove_add_last_spotify_signin_to_from_users.rb
+++ b/db/migrate/20200226171803_remove_add_last_spotify_signin_to_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveAddLastSpotifySigninToFromUsers < ActiveRecord::Migration[6.0]
+  def change
+
+    remove_column :users, :last_spotify_signin, :timestamp
+  end
+end

--- a/db/migrate/20200226171853_add_viewed_tag_screen_to_users.rb
+++ b/db/migrate/20200226171853_add_viewed_tag_screen_to_users.rb
@@ -1,0 +1,5 @@
+class AddViewedTagScreenToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :viewed_tag_screen, :boolean
+  end
+end

--- a/db/migrate/20200227093120_rename_viewed_tags_screen_to_viewed_tastes_screen_in_users.rb
+++ b/db/migrate/20200227093120_rename_viewed_tags_screen_to_viewed_tastes_screen_in_users.rb
@@ -1,0 +1,5 @@
+class RenameViewedTagsScreenToViewedTastesScreenInUsers < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :users, :viewed_tag_screen, :viewed_tastes_screen
+  end
+end

--- a/db/migrate/20200227113553_add_color_hex_to_genres.rb
+++ b/db/migrate/20200227113553_add_color_hex_to_genres.rb
@@ -1,0 +1,5 @@
+class AddColorHexToGenres < ActiveRecord::Migration[6.0]
+  def change
+    add_column :genres, :color_hex, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_27_093120) do
+ActiveRecord::Schema.define(version: 2020_02_27_113553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2020_02_27_093120) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "color_hex"
   end
 
   create_table "place_genres", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_25_155006) do
+ActiveRecord::Schema.define(version: 2020_02_27_093120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2020_02_25_155006) do
     t.string "nickname"
     t.string "provider"
     t.string "uid"
+    t.boolean "viewed_tastes_screen"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/lib/tasks/genre.rake
+++ b/lib/tasks/genre.rake
@@ -22,6 +22,21 @@ namespace :genre do
       'techno', 'trance', 'trip-hop', 'turkish', 'work-out', 'world-music'
     ]
 
-    genres.each { |genre| Genre.create(name: genre) }
+    hex_colors = [
+      '#7FCA74',
+      '#E5CE3B',
+      '#FCB255',
+      '#EF7A6D',
+      '#CE93E7',
+      '#3C93CD',
+      '#46CEE7',
+      '#2CA569',
+      '#FB93D5',
+      '#5C6A83',
+      '#C2C8D1',
+      '#828891'
+    ]
+
+    genres.sort.each_with_index { |genre, i| Genre.create(name: genre, color_hex: hex_colors[i % hex_colors.size]) }
   end
 end


### PR DESCRIPTION
- Screen is triggered only after the first Spotify Signin (added a field in the User DB)
- We first highlight the `genres` the user loves from Spotify (faked that, did not implement anything related to Spotify's API), to try to replicate that, create yourselft some `user_genres` after having run ```rails genre:seed```:
```ruby
UserGenre.create!(user: {your_user}, genre: {a_genre})
```
- Then follow the genres the user doesn't love
- TODO = Save / Destroy the `user_genres` when the user clicks on `Next`

![Screen+Recording+2020-02-27+at+01 51+PM](https://user-images.githubusercontent.com/12762571/75446772-540f9680-5968-11ea-9588-2df74da34e6a.gif)
