### PR TITLE
Fix sub genres

### DIFF
--- a/app/models/sub_genre.rb
+++ b/app/models/sub_genre.rb
@@ -5,19 +5,16 @@ class SubGenre < ApplicationRecord
   validates :name, uniqueness: { scope: [:genre_id] }
 
   def self.create_and_match(sub_genre)
-    puts sub_genre
     modified_sub_genre = sub_genre.gsub('hip hop', 'hip-hop')
     modified_sub_genre.gsub!('rap', 'hip-hop')
     modified_sub_genre.gsub!('thip-hop', 'trap')
     has_genre = false
     Genre.find_each do |genre|
-      puts "---------- try genre #{genre.name}"
       next unless modified_sub_genre.match?(genre.name)
+
       has_genre = true
-      puts "-----------------------match: #{has_genre}"
       create(name: sub_genre, genre: genre)
     end
-    puts has_genre
     create(name: sub_genre) unless has_genre
   end
 end

--- a/app/models/sub_genre.rb
+++ b/app/models/sub_genre.rb
@@ -5,16 +5,19 @@ class SubGenre < ApplicationRecord
   validates :name, uniqueness: { scope: [:genre_id] }
 
   def self.create_and_match(sub_genre)
-    modified_sub_genre = sub_genre.gsub('hip hop', 'hip-hop')
-    modified_sub_genre.gsub!('rap', 'hip-hop')
-    modified_sub_genre.gsub!('thip-hop', 'trap')
+    modified_sub_genre = sub_genre
+                         .gsub('hip hop', 'hip-hop')
+                         .gsub(/\brap\b/, 'hip-hop')
+
     has_genre = false
+
     Genre.find_each do |genre|
       next unless modified_sub_genre.match?(genre.name)
 
       has_genre = true
       create(name: sub_genre, genre: genre)
     end
+
     create(name: sub_genre) unless has_genre
   end
 end

--- a/app/models/sub_genre.rb
+++ b/app/models/sub_genre.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
 class SubGenre < ApplicationRecord
-  belongs_to :genre
+  belongs_to :genre, optional: true
   validates :name, uniqueness: { scope: [:genre_id] }
 
   def self.create_and_match(sub_genre)
+    puts sub_genre
+    modified_sub_genre = sub_genre.gsub('hip hop', 'hip-hop')
+    modified_sub_genre.gsub!('rap', 'hip-hop')
+    modified_sub_genre.gsub!('thip-hop', 'trap')
+    has_genre = false
     Genre.find_each do |genre|
-      next unless sub_genre.match?(genre.name)
-
+      puts "---------- try genre #{genre.name}"
+      next unless modified_sub_genre.match?(genre.name)
+      has_genre = true
+      puts "-----------------------match: #{has_genre}"
       create(name: sub_genre, genre: genre)
     end
-
-    create(name: sub_genre) unless find_by(name: sub_genre)
+    puts has_genre
+    create(name: sub_genre) unless has_genre
   end
 end

--- a/db/migrate/20200227210833_remove_genre_from_sub_genres.rb
+++ b/db/migrate/20200227210833_remove_genre_from_sub_genres.rb
@@ -1,0 +1,6 @@
+class RemoveGenreFromSubGenres < ActiveRecord::Migration[6.0]
+  def change
+
+    remove_column :sub_genres, :genre_id
+  end
+end

--- a/db/migrate/20200227210951_add_again_genre_to_sub_genres.rb
+++ b/db/migrate/20200227210951_add_again_genre_to_sub_genres.rb
@@ -1,0 +1,5 @@
+class AddAgainGenreToSubGenres < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :sub_genres, :genre, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_27_183627) do
+ActiveRecord::Schema.define(version: 2020_02_27_210951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 2020_02_27_183627) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "genre_id", null: false
+    t.bigint "genre_id"
     t.index ["genre_id"], name: "index_sub_genres_on_genre_id"
   end
 

--- a/lib/tasks/genre.rake
+++ b/lib/tasks/genre.rake
@@ -77,8 +77,6 @@ namespace :genre do
     require 'yaml'
     sub_genres = YAML.safe_load(File.read('lib/genres.yml'))
 
-    sub_genres.each do |sub_genre|
-      SubGenre.create_and_match(sub_genre)
-    end
+    sub_genres.each { |sub_genre| SubGenre.create_and_match(sub_genre) }
   end
 end

--- a/lib/tasks/genre.rake
+++ b/lib/tasks/genre.rake
@@ -78,9 +78,6 @@ namespace :genre do
     sub_genres = YAML.safe_load(File.read('lib/genres.yml'))
 
     sub_genres.each do |sub_genre|
-      # sub_genre.gsub('hip hop', 'hip-hop')
-      # sub_genre.gsub('rap', 'hip-hop')
-      # sub_genre.gsub('thip-hop', 'trap')
       SubGenre.create_and_match(sub_genre)
     end
   end

--- a/lib/tasks/genre.rake
+++ b/lib/tasks/genre.rake
@@ -6,11 +6,10 @@ namespace :genre do
     genres = [
       'r&b',
       'urban',
-      'hip hop',
+      'hip-hop',
       'soul',
       'pop',
       'dance',
-      'rap',
       'funk',
       'indie',
       'blues',
@@ -79,9 +78,9 @@ namespace :genre do
     sub_genres = YAML.safe_load(File.read('lib/genres.yml'))
 
     sub_genres.each do |sub_genre|
-      sub_genre.gsub!('hip hop', 'hip-hop')
-      sub_genre.gsub!('rap', 'hip-hop')
-
+      # sub_genre.gsub('hip hop', 'hip-hop')
+      # sub_genre.gsub('rap', 'hip-hop')
+      # sub_genre.gsub('thip-hop', 'trap')
       SubGenre.create_and_match(sub_genre)
     end
   end


### PR DESCRIPTION
Je me suis permis d’itérer sur les sub genres car :
• Les subgenres n’étaient pas créés quand on ne trouvait pas de genre, pour plusieurs raisons : le belongs_to implique que le create va fail si on ne trouve pas de genre et dans la migration était en plus passé un null: false au genre:reference dans sub_genres
• on renommait trap en thip-hop :D
• on cherchait hip-hop alors que dans genres c’est hip hop donc je l’ai rename
• on stockait le nom modifié du sub_genre (par exemple au lieu de stocker rap conscient on stockait donc hip-hop conscient — à cause des gsub! destructifs — ce qui risque de poser problème quand on va récupérer rap conscient de Spotify et qu’on va vouloir faire du matching)