### PR TITLE
Fix tags on index that were not centered

### DIFF
--- a/app/assets/stylesheets/pages/_places_index.scss
+++ b/app/assets/stylesheets/pages/_places_index.scss
@@ -49,9 +49,8 @@
   }
 }
 
-
 .bar-search {
-  background: #03272F;
+  background: #03272f;
   height: 56px;
 }
 
@@ -86,4 +85,9 @@
   .place-tag {
     margin: 5px;
   }
+}
+
+.place-tag {
+  align-items: center;
+  display: flex;
 }


### PR DESCRIPTION
# Before
<img width="48" alt="Capture d’écran 2020-03-01 à 20 40 28" src="https://user-images.githubusercontent.com/1598346/75632492-e5973680-5bfc-11ea-9015-3bad7263b4ce.png">

# After

<img width="49" alt="Capture d’écran 2020-03-01 à 20 40 04" src="https://user-images.githubusercontent.com/1598346/75632481-d6b08400-5bfc-11ea-867d-0399f9d512a3.png">

