### PR TITLE
the green line is always present

### DIFF
--- a/app/assets/stylesheets/components/_bottom_navbar.scss
+++ b/app/assets/stylesheets/components/_bottom_navbar.scss
@@ -1,7 +1,7 @@
 .bottom-navbar {
   align-items: center;
   background: $my-black;
-  border-top: $my-green 1px solid;
+  border-top: $my-green 2px solid;
   display: flex;
   font-size: 25px;
   height: 56px;


### PR DESCRIPTION
Before
![Capture d’écran 2020-03-02 à 10 09 45](https://user-images.githubusercontent.com/57875309/75661718-1bc0ce80-5c6e-11ea-8133-c7e0a5867058.png)
The green line was too thin, impossible to see it in scrolling the app.

After
![Capture d’écran 2020-03-02 à 10 09 28](https://user-images.githubusercontent.com/57875309/75661771-37c47000-5c6e-11ea-944e-351d6280c06f.png)
Just one more px to always have the separated line present in the navbar